### PR TITLE
Add multiple feeds to `creamcrop`

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -2,7 +2,7 @@
 
 <br><br>
 
-# Creamcrop <small>v0.1.0</small> 
+# Creamcrop <small>v0.2.0</small> 
 
 > A cream-of-the-crop, top-of-the-top, slice-and-chop, absolutely minimalist news getter
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,7 @@
 * **Documentation**
     * [Home](/)
     * [Guide](./guide.md)
+    * [Config](./config.md)
 * **Other Info**
     * [FAQ](./faq.md)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,30 @@
+> Configuration for the package
+
+Configuration for the package is located at the `.creamcroprc` file, 
+which is auto-generated, and currently only contains the feeds to use
+when generating the webiste. However, there are plans to extend this 
+to allow for more configuration in the package, including custom formats,
+website templates, and more.
+
+
+## Configuration Syntax
+
+There is a simple configuration syntax used in creamcrop.
+
+```JSON
+{
+    "feeds": [
+        "feed1__url",
+        "feed2_url",
+        "feed3_url"
+    ]
+}
+```
+
+Later on, more parameters will be added.
+
+## Valid parameters
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+|  `feeds`  | Array of feeds to parse | No default. **Required**. |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,15 +6,15 @@ As you might have noticed, creamcrop is still in alpha, as [according to the Sem
 
 Infact, here's a list of things we want to get done before we release `v1`:
 
-- Multiple RSS feeds 
-- Better websites
-- Config files
-- Fast. Fast. Fast. (ie. We want it to be faster.)
-- Filters
-- Git tracking
-- Additional Feed types - atom, JSON
-- Probably a whole lot of bug fixes
-- and other things we haven't thought about yet.
+- [x] ~Multiple RSS feeds~ 
+- [ ] Better websites
+- [x] ~Config files~
+- [ ] Fast. Fast. Fast. (ie. We want it to be faster.)
+- [ ] Filters
+- [ ] Git tracking
+- [ ] Additional Feed types - atom, JSON
+- [ ] Probably a whole lot of bug fixes
+- [ ] and other things we haven't thought about yet.
 
 ## Can I contribute?
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -36,7 +36,7 @@ Usage: (creamcrop|cream) <command> [options]
 
 Commands:
   (creamcrop|cream) fetch [url]  Fetch a feed.
-  (creamcrop|cream) serve [url]  Serves website from RSS feed
+  (creamcrop|cream) serve [dir]  Serves website from config file in [dir].
   (creamcrop|cream) about        Displays package info and exits.
 
 Options:
@@ -47,26 +47,23 @@ Options:
 
 ### `fetch [url]`
 
-The `fetch` command fetches a feed and prints a JSON output of the feed. This is useful if you'd like to verify that a feed exists.
+The `fetch` command fetches a feed, check's if it's valid, and adds it to the config file.
+
+?> The config file is a required file if using the [`serve` command](#serve-url). See more info at [config](./config.md)
 
 ```sh
 $ cream fetch https://www.feedforall.com/sample.xml
-{
-  items: [
-    {
-      title: 'RSS Solutions for Restaurants',
-      link: 'http://www.feedforall.com/restaurant.htm',
-      pubDate: 'Tue, 19 Oct 2004 11:09:11 -0400',
-      comments: 'http://www.feedforall.com/forum',
-# and so on...
+Valid feed... adding to config
 ```
 
-### `serve [url]`
+### `serve [dir]`
 
-The `serve` command fetches the URL and gives a HTML display.
+The `serve` command finds the config file in the given directory and serves a website using the configuration specified.
+See [config](./config.md) for more info on the config file.
 
 ```sh
-$ cream serve https://www.feedforall.com/sample.xml
+$ cream serve ./
+Found config file, generating website...
 Server running at http://localhost:8080
 ```
 
@@ -79,7 +76,7 @@ $ cream about
 creamcrop
 A cream-of-the-crop, top-of-the-top, slice-and-chop, absolutely minimalist news getter.
 Qlabs (@Quantalabs)
-0.1.0
+0.2.0
 ```
 
 ## Options
@@ -95,7 +92,7 @@ Usage: (creamcrop|cream) <command> [options]
 
 Commands:
   (creamcrop|cream) fetch [url]  Fetch a feed.
-  (creamcrop|cream) serve [url]  Serves website from RSS feed
+  (creamcrop|cream) serve [dir]  Serves website from config file in [dir].
   (creamcrop|cream) about        Displays package info and exits.
 
 Options:
@@ -120,5 +117,5 @@ Options:
 The version command gives you the version info of the package.
 ```sh
 $ cream --version
-0.1.0
+0.2.0
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "creamcrop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "boxen": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "creamcrop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A cream-of-the-crop, top-of-the-top, slice-and-chop, absolutely minimalist news getter.",
   "main": "src/index.js",
   "bin": {

--- a/src/utils/web.js
+++ b/src/utils/web.js
@@ -26,6 +26,8 @@ async function serve(dir) {
       feed.items.push({
         title: data.items[fitem].title,
         link: data.items[fitem].link,
+        feed: data.title,
+        feedlink: data.link,
       });
     }
   }
@@ -46,7 +48,7 @@ async function serve(dir) {
           <ul>
             ${feed.items.map(item => `
               <li>
-                <a href="${item.link}">${item.title}</a>
+                <a href="${item.link}">${item.title}</a> from <a href="${item.feedlink}">${item.feed}</a>
               </li>
             `).join('\n')}
           </ul>

--- a/src/utils/web.js
+++ b/src/utils/web.js
@@ -1,11 +1,35 @@
 const http = require('http');
+const fs = require('fs');
+const rss = require('./rss');
 
 /**
  * Serve website
  * 
- * @param {Object} feed - RSS Feed Object
+ * @param {Object} dir - Config file directory
 */
-function serve(feed) {
+async function serve(dir) {
+  if (fs.existsSync(dir+'/.creamcroprc') || fs.existsSync(dir+'.creamcroprc.json')) {
+    console.log('Found config file, generating website...')
+  }
+  else {
+    console.log('Directory not found or No Config File: ' + dir);
+    process.exit(1);
+  }
+  let feed = {
+    items: []
+  };
+  
+  let config = JSON.parse(fs.readFileSync(dir+'/.creamcroprc'));
+  for (var x in config.feeds) {
+    let data = await rss.parse(config.feeds[x]);
+    for (var fitem in data.items) {
+      feed.items.push({
+        title: data.items[fitem].title,
+        link: data.items[fitem].link,
+      });
+    }
+  }
+
   const requestListener = function (req, res) {
     res.writeHead(200, {
       'Content-Type': 'text/html'

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -8,9 +8,12 @@ cream --version
 
 # Fetching
 cream fetch https://medium.com/feed/swlh
+cream fetch https://reddit.com/.rss
 
 # Serving
-cream serve https://medium.com/feed/swlh & sleep 10 ; kill $!
+cream serve . & sleep 10 ; kill $!
 
 # About
 cream about
+
+rm -rf ./.creamcroprc


### PR DESCRIPTION
## Overview
Adds multiple feeds to the RSS reader, which introduces the creamcrop config file, which is called `.creamcroprc`. The config file currently only holds the feeds, but will be expanded in the future, before v1.

## Changelist

- Add multiple feeds
- Update documentation
- Add config file validation