### PR TITLE
Add Custom Website Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.3.0
+
+Adds:
+    - Custom Output Format
+    - Custom HTML templates
+
 # v0.2.0
 
 Adds:

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -2,7 +2,7 @@
 
 <br><br>
 
-# Creamcrop <small>v0.2.0</small> 
+# Creamcrop <small>v0.3.0</small> 
 
 > A cream-of-the-crop, top-of-the-top, slice-and-chop, absolutely minimalist news getter
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,15 +16,18 @@ There is a simple configuration syntax used in creamcrop.
     "feeds": [
         "feed1__url",
         "feed2_url",
-        "feed3_url"
+        "feed3_url",
+        ...
     ]
 }
 ```
 
-Later on, more parameters will be added.
+Currently, `feeds` is the only required parameter.
 
 ## Valid parameters
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-|  `feeds`  | Array of feeds to parse | No default. **Required**. |
+| Parameter | Description | Default | Values |
+| --------- | ----------- | ------- | ------ |
+|  `feeds`  | Array of feeds to parse | No default. **Required**. | An array of URLs to feeds |
+| `format` | The format of the output. Each value should be surrounded by `%`. | `<a href="%link%">%item%</a> from <a href="%feedlink%">%feed%</a>` | `%feed%`- The name of the RSS feed the item is in. <br> `%feedlink%` - The RSS feed's link that the item is in. <br> `%item%` - The name of the RSS feed Item. <br> `%itemlink%` Link to the item. |
+| `custom` | A custom HTML template. Inside the HTML, use `%feed%`, which will be replaced by the content of the feed. |  A basic HTML page. | The relative path to the HTML template file |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -76,7 +76,7 @@ $ cream about
 creamcrop
 A cream-of-the-crop, top-of-the-top, slice-and-chop, absolutely minimalist news getter.
 Qlabs (@Quantalabs)
-0.2.0
+0.3.0
 ```
 
 ## Options
@@ -117,5 +117,5 @@ Options:
 The version command gives you the version info of the package.
 ```sh
 $ cream --version
-0.2.0
+0.3.0
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "creamcrop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A cream-of-the-crop, top-of-the-top, slice-and-chop, absolutely minimalist news getter.",
   "main": "src/index.js",
   "bin": {

--- a/src/utils/web.js
+++ b/src/utils/web.js
@@ -32,6 +32,15 @@ async function serve(dir) {
     }
   }
 
+  function format(title, link, feedlink, feed) {
+    var format = config.format
+    format = format.replace(/%title%/g, title);
+    format = format.replace(/%link%/g, link);
+    format = format.replace(/%feed%/g, feed);
+    format = format.replace(/%feedlink%/g, feedlink);
+    return format;
+  }
+
   const requestListener = function (req, res) {
     res.writeHead(200, {
       'Content-Type': 'text/html'
@@ -48,7 +57,7 @@ async function serve(dir) {
           <ul>
             ${feed.items.map(item => `
               <li>
-                <a href="${item.link}">${item.title}</a> from <a href="${item.feedlink}">${item.feed}</a>
+                ${format(item.title, item.link, item.feedlink, item.feed)}
               </li>
             `).join('\n')}
           </ul>

--- a/src/utils/web.js
+++ b/src/utils/web.js
@@ -33,9 +33,6 @@ async function serve(dir) {
   }
 
   function format(title, link, feedlink, feed) {
-    process.stdout.cursorTo(0);
-    process.stdout.clearLine();
-    process.stdout.write(`Going through ${title}...`)
     if (config.format !== undefined) {
       var format = config.format
       format = format.replace(/%title%/g, title);


### PR DESCRIPTION
## Overview
This PR adds custom website templates and formatting.

## Changelist

- Add custom website templates
- Add custom format for output in `cream serve`. eg. You can change it from `<a href='[LINK]'>ITEM</a> from <a href='[FEEDLINK]'>FEED</a>` to something else.