### PR TITLE
Fix License Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm run lint
   
 ### License
 
-The creamcrop project is licensed under the GPL-3.0 license.
+The creamcrop project is licensed under the MIT license.
 
   
 ### Documentation


### PR DESCRIPTION
Fixes a license error, stating the license is GPL-3.0, not the MIT license.